### PR TITLE
Add internal test exports and improve golangci-lint configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
                 # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
                 # queries: security-extended,security-and-quality
 
-          # If the analyze step fails for one of the languages you are analyzing with
+          # If the analyze-step fails for one of the languages you are analyzing with
           # "We were unable to automatically build your code", modify the matrix above
           # to set the build mode to "manual" for that language. Then modify this step
           # to build your code.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
                 # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
                 # queries: security-extended,security-and-quality
 
-          # If the analyze-step fails for one of the languages you are analyzing with
+          # If the "analyze" step fails for one of the languages you are analyzing with
           # "We were unable to automatically build your code", modify the matrix above
           # to set the build mode to "manual" for that language. Then modify this step
           # to build your code.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,17 +53,14 @@ linters:
                         - "!**/examples/**/*"
                     allow:
                         - $gostd
-                        - gopkg.in/yaml.v3
-                        - github.com/Masterminds/sprig/v3
                 test:
                     files:
                         - $test
                         - "**/examples/**/*"
                     allow:
                         - $gostd
-                        - gopkg.in/yaml.v3
-                        - github.com/Masterminds/sprig/v3
                         - github.com/stretchr/testify/assert
+                        - github.com/stretchr/testify/require
                         - github.com/AlphaOne1/dmorph
                         - modernc.org/sqlite
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,6 +82,11 @@ linters:
 
         varnamelen:
             max-distance: 10
+            ignore-names:
+              - ctx
+              - db
+              - err
+              - tx
 
         whitespace:
             multi-if: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+# Copyright the dmorph contributors.
+# SPDX-License-Identifier: MPL-2.0
+
 # Configuration file for golangci-lint
 # See https://golangci-lint.run/usage/configuration/ for more information
 
@@ -9,25 +12,83 @@ run:
 
 linters:
     default: all
-    #enable:
-    #    # Default linters
-    #    - errcheck
-    #    - govet
-    #    - ineffassign
-    #    - staticcheck
-    #    - unused
-    #    # Additional linters
-    #    - gosec
-    #    - misspell
-    #    - revive
-    #    - bodyclose
-    #    - noctx
+
+    disable:
+        - exhaustruct
+        - forbidigo
+        - noinlineerr
+        - nonamedreturns
+        - wsl
+        - wsl_v5
 
     exclusions:
+        warn-unused: true
+
         rules:
-            - path: main_test.go
+            - path: _test\.go
               linters:
-                  - gosec
+                  - cyclop
+                  - dupl
+                  - dupword
+                  - err113
+                  - funlen
+                  - gocognit
+                  - maintidx
+                  - nestif
+
+            - path: examples/
+              linters:
+                  - err113
+
+    settings:
+        cyclop:
+            max-complexity: 25
+
+        depguard:
+            rules:
+                main:
+                    files:
+                        - $all
+                        - "!$test"
+                        - "!**/examples/**/*"
+                    allow:
+                        - $gostd
+                        - gopkg.in/yaml.v3
+                        - github.com/Masterminds/sprig/v3
+                test:
+                    files:
+                        - $test
+                        - "**/examples/**/*"
+                    allow:
+                        - $gostd
+                        - gopkg.in/yaml.v3
+                        - github.com/Masterminds/sprig/v3
+                        - github.com/stretchr/testify/assert
+                        - github.com/AlphaOne1/dmorph
+                        - modernc.org/sqlite
+
+        exhaustive:
+            default-signifies-exhaustive: true
+
+        mnd:
+            ignored-numbers:
+                - "2"
+
+        paralleltest:
+            ignore-missing: true
+
+        perfsprint:
+            errorf: false
+
+        testpackage:
+            skip-regexp: internal_test\.go
+
+        varnamelen:
+            max-distance: 10
+
+        whitespace:
+            multi-if: true
+            multi-func: true
 
 issues:
     max-issues-per-linter: 0

--- a/dialects.go
+++ b/dialects.go
@@ -11,7 +11,7 @@ import (
 
 // BaseDialect is a convenience type for databases that manage the necessary operations solely using
 // queries. Defining the CreateTemplate, AppliedTemplate and RegisterTemplate enables the BaseDialect to
-// perform all the necessary operation to fulfill the Dialect interface.
+// perform all the necessary operations to fulfill the Dialect interface.
 type BaseDialect struct {
 	CreateTemplate   string // statement ensuring the existence of the migration table
 	AppliedTemplate  string // statement getting applied migrations ordered by application date
@@ -32,11 +32,13 @@ func (b BaseDialect) EnsureMigrationTableExists(db *sql.DB, tableName string) er
 
 	if execErr != nil {
 		rollbackErr := tx.Rollback()
+
 		return errors.Join(execErr, rollbackErr)
 	}
 
 	if err := tx.Commit(); err != nil {
 		rollbackErr := tx.Rollback()
+
 		return errors.Join(err, rollbackErr)
 	}
 

--- a/dialects.go
+++ b/dialects.go
@@ -26,11 +26,7 @@ func (b BaseDialect) EnsureMigrationTableExists(db *sql.DB, tableName string) er
 		return err
 	}
 
-	defer func() { _ = tx.Rollback() }()
-
-	_, execErr := tx.Exec(fmt.Sprintf(b.CreateTemplate, tableName))
-
-	if execErr != nil {
+	if _, execErr := tx.Exec(fmt.Sprintf(b.CreateTemplate, tableName)); execErr != nil {
 		rollbackErr := tx.Rollback()
 
 		return errors.Join(execErr, rollbackErr)

--- a/dialects_test.go
+++ b/dialects_test.go
@@ -4,7 +4,6 @@
 package dmorph_test
 
 import (
-	"context"
 	"database/sql"
 	"os"
 	"regexp"
@@ -80,10 +79,10 @@ func TestCallsOnClosedDB(t *testing.T) {
 	}
 
 	assert.Error(t,
-		dmorph.DialectSQLite().EnsureMigrationTableExists(context.Background(), db, "irrelevant"),
+		dmorph.DialectSQLite().EnsureMigrationTableExists(t.Context(), db, "irrelevant"),
 		"expected error on closed database")
 
-	_, err := dmorph.DialectSQLite().AppliedMigrations(context.Background(), db, "irrelevant")
+	_, err := dmorph.DialectSQLite().AppliedMigrations(t.Context(), db, "irrelevant")
 	assert.Error(t, err, "expected error on closed database")
 }
 
@@ -114,7 +113,7 @@ func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	assert.Error(t, dialect.EnsureMigrationTableExists(context.Background(), db, "test"), "expected error")
+	assert.Error(t, dialect.EnsureMigrationTableExists(t.Context(), db, "test"), "expected error")
 }
 
 // TestEnsureMigrationTableExistsCommitError tests the behavior of EnsureMigrationTableExists
@@ -158,5 +157,5 @@ func TestEnsureMigrationTableExistsCommitError(t *testing.T) {
 
 	assert.NoError(t, execErr, "foreign keys checking could not be enabled")
 
-	assert.Error(t, d.EnsureMigrationTableExists(context.Background(), db, "test"), "expected error")
+	assert.Error(t, d.EnsureMigrationTableExists(t.Context(), db, "test"), "expected error")
 }

--- a/dialects_test.go
+++ b/dialects_test.go
@@ -89,7 +89,7 @@ func TestCallsOnClosedDB(t *testing.T) {
 // TestEnsureMigrationTableExistsSQLError tests the EnsureMigrationTableExists function
 // for handling SQL errors during execution.
 func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
-	d := dmorph.BaseDialect{
+	dialect := dmorph.BaseDialect{
 		CreateTemplate: `
             CRATE TABLE test (
                 id        VARCHAR(255) PRIMARY KEY,
@@ -113,7 +113,7 @@ func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	assert.Error(t, d.EnsureMigrationTableExists(db, "test"), "expected error")
+	assert.Error(t, dialect.EnsureMigrationTableExists(db, "test"), "expected error")
 }
 
 // TestEnsureMigrationTableExistsCommitError tests the behavior of EnsureMigrationTableExists

--- a/dialects_test.go
+++ b/dialects_test.go
@@ -61,6 +61,7 @@ func TestDialectStatements(t *testing.T) {
 // TestCallsOnClosedDB verifies that methods fail as expected when called on a closed database connection.
 func TestCallsOnClosedDB(t *testing.T) {
 	db, _ := openTempSQLite(t)
+	db.Close()
 
 	assert.Error(t,
 		dmorph.DialectSQLite().EnsureMigrationTableExists(t.Context(), db, "irrelevant"),

--- a/dialects_test.go
+++ b/dialects_test.go
@@ -4,6 +4,7 @@
 package dmorph_test
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"regexp"
@@ -79,10 +80,10 @@ func TestCallsOnClosedDB(t *testing.T) {
 	}
 
 	assert.Error(t,
-		dmorph.DialectSQLite().EnsureMigrationTableExists(db, "irrelevant"),
+		dmorph.DialectSQLite().EnsureMigrationTableExists(context.Background(), db, "irrelevant"),
 		"expected error on closed database")
 
-	_, err := dmorph.DialectSQLite().AppliedMigrations(db, "irrelevant")
+	_, err := dmorph.DialectSQLite().AppliedMigrations(context.Background(), db, "irrelevant")
 	assert.Error(t, err, "expected error on closed database")
 }
 
@@ -113,7 +114,7 @@ func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	assert.Error(t, dialect.EnsureMigrationTableExists(db, "test"), "expected error")
+	assert.Error(t, dialect.EnsureMigrationTableExists(context.Background(), db, "test"), "expected error")
 }
 
 // TestEnsureMigrationTableExistsCommitError tests the behavior of EnsureMigrationTableExists
@@ -157,5 +158,5 @@ func TestEnsureMigrationTableExistsCommitError(t *testing.T) {
 
 	assert.NoError(t, execErr, "foreign keys checking could not be enabled")
 
-	assert.Error(t, d.EnsureMigrationTableExists(db, "test"), "expected error")
+	assert.Error(t, d.EnsureMigrationTableExists(context.Background(), db, "test"), "expected error")
 }

--- a/dialects_test.go
+++ b/dialects_test.go
@@ -1,7 +1,7 @@
 // Copyright the DMorph contributors.
 // SPDX-License-Identifier: MPL-2.0
 
-package dmorph
+package dmorph_test
 
 import (
 	"database/sql"
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/AlphaOne1/dmorph"
 )
 
 // TestDialectStatements verifies that each database dialect has valid and
@@ -19,15 +21,15 @@ func TestDialectStatements(t *testing.T) {
 	// that the statements for the databases are somehow filled
 	tests := []struct {
 		name   string
-		caller func() BaseDialect
+		caller func() dmorph.BaseDialect
 	}{
-		{name: "CSVQ", caller: DialectCSVQ},
-		{name: "DB2", caller: DialectDB2},
-		{name: "MSSQL", caller: DialectMSSQL},
-		{name: "MySQL", caller: DialectMySQL},
-		{name: "Oracle", caller: DialectOracle},
-		{name: "Postgres", caller: DialectPostgres},
-		{name: "SQLite", caller: DialectSQLite},
+		{name: "CSVQ", caller: dmorph.DialectCSVQ},
+		{name: "DB2", caller: dmorph.DialectDB2},
+		{name: "MSSQL", caller: dmorph.DialectMSSQL},
+		{name: "MySQL", caller: dmorph.DialectMySQL},
+		{name: "Oracle", caller: dmorph.DialectOracle},
+		{name: "Postgres", caller: dmorph.DialectPostgres},
+		{name: "SQLite", caller: dmorph.DialectSQLite},
 	}
 
 	re := regexp.MustCompile("%s")
@@ -77,17 +79,17 @@ func TestCallsOnClosedDB(t *testing.T) {
 	}
 
 	assert.Error(t,
-		DialectSQLite().EnsureMigrationTableExists(db, "irrelevant"),
+		dmorph.DialectSQLite().EnsureMigrationTableExists(db, "irrelevant"),
 		"expected error on closed database")
 
-	_, err := DialectSQLite().AppliedMigrations(db, "irrelevant")
+	_, err := dmorph.DialectSQLite().AppliedMigrations(db, "irrelevant")
 	assert.Error(t, err, "expected error on closed database")
 }
 
 // TestEnsureMigrationTableExistsSQLError tests the EnsureMigrationTableExists function
 // for handling SQL errors during execution.
 func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
-	d := BaseDialect{
+	d := dmorph.BaseDialect{
 		CreateTemplate: `
             CRATE TABLE test (
                 id        VARCHAR(255) PRIMARY KEY,
@@ -114,9 +116,10 @@ func TestEnsureMigrationTableExistsSQLError(t *testing.T) {
 	assert.Error(t, d.EnsureMigrationTableExists(db, "test"), "expected error")
 }
 
-// TestEnsureMigrationTableExistsCommitError tests the behavior of EnsureMigrationTableExists when a commit error occurs.
+// TestEnsureMigrationTableExistsCommitError tests the behavior of EnsureMigrationTableExists
+// when a commit error occurs.
 func TestEnsureMigrationTableExistsCommitError(t *testing.T) {
-	d := BaseDialect{
+	d := dmorph.BaseDialect{
 		CreateTemplate: `
 			CREATE TABLE t0 (
 			    id INTEGER PRIMARY KEY

--- a/exports_internal_test.go
+++ b/exports_internal_test.go
@@ -1,0 +1,15 @@
+package dmorph
+
+import "database/sql"
+
+// The exported names in this file are only used for internal testing and are not part of the public API.
+
+var (
+	TapplyStepsStream    = applyStepsStream
+	TmigrationFromFileFS = migrationFromFileFS
+	TmigrationOrder      = migrationOrder
+)
+
+func (m *Morpher) TapplyMigrations(db *sql.DB, lastMigration string) error {
+	return m.applyMigrations(db, lastMigration)
+}

--- a/exports_internal_test.go
+++ b/exports_internal_test.go
@@ -1,6 +1,9 @@
 package dmorph
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
 
 // The exported names in this file are only used for internal testing and are not part of the public API.
 
@@ -10,6 +13,6 @@ var (
 	TmigrationOrder      = migrationOrder
 )
 
-func (m *Morpher) TapplyMigrations(db *sql.DB, lastMigration string) error {
-	return m.applyMigrations(db, lastMigration)
+func (m *Morpher) TapplyMigrations(ctx context.Context, db *sql.DB, lastMigration string) error {
+	return m.applyMigrations(ctx, db, lastMigration)
 }

--- a/file_migration.go
+++ b/file_migration.go
@@ -66,9 +66,9 @@ func WithMigrationFromFileFS(name string, dir fs.FS) MorphOption {
 
 // WithMigrationsFromFS generates a FileMigration that will run all migration scripts of the files in the given
 // filesystem.
-func WithMigrationsFromFS(d fs.ReadDirFS) MorphOption {
+func WithMigrationsFromFS(d fs.FS) MorphOption {
 	return func(morpher *Morpher) error {
-		dirEntry, err := d.ReadDir(".")
+		dirEntry, err := fs.ReadDir(d, ".")
 
 		if err == nil {
 			for _, entry := range dirEntry {

--- a/file_migration.go
+++ b/file_migration.go
@@ -72,6 +72,7 @@ func WithMigrationsFromFS(d fs.ReadDirFS) MorphOption {
 		if err == nil {
 			for _, entry := range dirEntry {
 				morpher.Log.Info("entry", slog.String("name", entry.Name()))
+
 				if entry.Type().IsRegular() {
 					morpher.Migrations = append(morpher.Migrations,
 						migrationFromFileFS(entry.Name(), d, morpher.Log))
@@ -83,7 +84,7 @@ func WithMigrationsFromFS(d fs.ReadDirFS) MorphOption {
 	}
 }
 
-// migrationFromFileFS creates a FileMigration instance for a specific migration file from an fs.FS directory.
+// migrationFromFileFS creates a FileMigration instance for a specific migration file from a fs.FS directory.
 func migrationFromFileFS(name string, dir fs.FS, log *slog.Logger) FileMigration {
 	return FileMigration{
 		Name: name,
@@ -105,8 +106,8 @@ func migrationFromFileFS(name string, dir fs.FS, log *slog.Logger) FileMigration
 // applyStepsStream executes database migration steps read from an io.Reader, separated by semicolons, in a transaction.
 // Returns the corresponding error if any step execution fails. Also, as some database drivers or engines seem to not
 // support comments, leading comments are removed. This function does not undertake efforts to scan the SQL to find
-// other comments. So leading comments telling what a step is going to do, work. But comments in the middle of a
-// statement will not be removed. At least with SQLite this will lead to hard to find errors.
+// other comments. Such leading comments telling what a step is going to do, work. But comments in the middle of a
+// statement will not be removed. At least with SQLite this will lead to hard-to-find errors.
 func applyStepsStream(tx *sql.Tx, r io.Reader, id string, log *slog.Logger) error {
 	buf := bytes.Buffer{}
 
@@ -138,7 +139,7 @@ func applyStepsStream(tx *sql.Tx, r io.Reader, id string, log *slog.Logger) erro
 		}
 	}
 
-	// cleanup after, for final statement without the closing ; on a new line
+	// cleanup after, for the final statement without the closing `;` on a new line
 	if buf.Len() > 0 {
 		log.Info("migration step",
 			slog.String("id", id),

--- a/file_migration.go
+++ b/file_migration.go
@@ -120,14 +120,14 @@ func applyStepsStream(tx *sql.Tx, r io.Reader, id string, log *slog.Logger) erro
 	var i int
 
 	for i = 0; scanner.Scan(); {
-		buf.Write(scanner.Bytes())
-
 		if newStep && strings.HasPrefix(scanner.Text(), "--") {
 			// skip leading comments
 			continue
 		}
 
 		newStep = false
+
+		buf.Write(scanner.Bytes())
 
 		if scanner.Text() == ";" {
 			log.Info("migration step",

--- a/file_migration.go
+++ b/file_migration.go
@@ -109,9 +109,13 @@ func migrationFromFileFS(name string, dir fs.FS, log *slog.Logger) FileMigration
 // other comments. Such leading comments telling what a step is going to do, work. But comments in the middle of a
 // statement will not be removed. At least with SQLite this will lead to hard-to-find errors.
 func applyStepsStream(tx *sql.Tx, r io.Reader, id string, log *slog.Logger) error {
+	const InitialScannerBufSize = 64 * 1024
+	const MaxScannerBufSize = 1024 * 1024
+
 	buf := bytes.Buffer{}
 
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, InitialScannerBufSize), MaxScannerBufSize)
 	newStep := true
 	var i int
 

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWithMigrationFromFile(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	runErr := dmorph.Run(t.Context(),
 		db,
@@ -27,7 +27,7 @@ func TestWithMigrationFromFile(t *testing.T) {
 }
 
 func TestWithMigrationFromFileError(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	runErr := dmorph.Run(t.Context(),
 		db,
@@ -52,7 +52,7 @@ func TestMigrationFromFileFSError(t *testing.T) {
 
 // TestApplyStepsStreamError tests error handling in applyStepsStream.
 func TestApplyStepsStreamError(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	buf := bytes.Buffer{}
 	buf.WriteString("utter nonsense")

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -1,7 +1,7 @@
 // Copyright the DMorph contributors.
 // SPDX-License-Identifier: MPL-2.0
 
-package dmorph
+package dmorph_test
 
 import (
 	"bytes"
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/AlphaOne1/dmorph"
 )
 
 func TestWithMigrationFromFile(t *testing.T) {
@@ -31,9 +33,9 @@ func TestWithMigrationFromFile(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := Run(db,
-		WithDialect(DialectSQLite()),
-		WithMigrationFromFile("testData/01_base_table.sql"))
+	runErr := dmorph.Run(db,
+		dmorph.WithDialect(dmorph.DialectSQLite()),
+		dmorph.WithMigrationFromFile("testData/01_base_table.sql"))
 
 	assert.NoError(t, runErr, "did not expect an error")
 }
@@ -55,21 +57,22 @@ func TestWithMigrationFromFileError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := Run(db,
-		WithDialect(DialectSQLite()),
-		WithMigrationFromFile("testData/00_non_existent.sql"))
+	runErr := dmorph.Run(db,
+		dmorph.WithDialect(dmorph.DialectSQLite()),
+		dmorph.WithMigrationFromFile("testData/00_non_existent.sql"))
 
 	var pathErr *fs.PathError
 	assert.ErrorAs(t, runErr, &pathErr, "unexpected error")
 }
 
-// TestMigrationFromFileFSError validates that migrationFromFileFS returns an error when the specified file does not exist.
+// TestMigrationFromFileFSError validates that migrationFromFileFS returns an error
+// when the specified file does not exist.
 func TestMigrationFromFileFSError(t *testing.T) {
 	dir, dirErr := os.OpenRoot("testData")
 
 	assert.NoError(t, dirErr, "could not open test data directory")
 
-	mig := migrationFromFileFS("nonexistent", dir.FS(), slog.Default())
+	mig := dmorph.TmigrationFromFileFS("nonexistent", dir.FS(), slog.Default())
 
 	err := mig.Migrate(nil)
 
@@ -101,7 +104,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 
 	assert.NoError(t, txErr, "expected no tx error")
 
-	err := applyStepsStream(tx, &buf, "test", slog.Default())
+	err := dmorph.TapplyStepsStream(tx, &buf, "test", slog.Default())
 
 	assert.Error(t, err, "expected error")
 
@@ -114,7 +117,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 	buf.Reset()
 	buf.WriteString("utter nonsense\n;")
 
-	err = applyStepsStream(tx, &buf, "test", slog.Default())
+	err = dmorph.TapplyStepsStream(tx, &buf, "test", slog.Default())
 
 	assert.Error(t, err, "expected error")
 

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/AlphaOne1/dmorph"
 )
@@ -73,7 +74,7 @@ func TestWithMigrationFromFileError(t *testing.T) {
 func TestMigrationFromFileFSError(t *testing.T) {
 	dir, dirErr := os.OpenRoot("testData")
 
-	assert.NoError(t, dirErr, "could not open test data directory")
+	require.NoError(t, dirErr, "could not open test data directory")
 
 	mig := dmorph.TmigrationFromFileFS("nonexistent", dir.FS(), slog.Default())
 

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/AlphaOne1/dmorph"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithMigrationFromFile(t *testing.T) {
@@ -102,17 +103,17 @@ func TestApplyStepsStreamError(t *testing.T) {
 
 	tx, txErr := db.BeginTx(t.Context(), nil)
 
-	assert.NoError(t, txErr, "expected no tx error")
+	require.NoError(t, txErr, "expected no tx error")
 
 	err := dmorph.TapplyStepsStream(context.Background(), tx, &buf, "test", slog.Default())
 
-	assert.Error(t, err, "expected error")
+	require.Error(t, err, "expected error")
 
 	_ = tx.Rollback()
 
 	tx, txErr = db.BeginTx(t.Context(), nil)
 
-	assert.NoError(t, txErr, "expected no tx error")
+	require.NoError(t, txErr, "expected no tx error")
 
 	buf.Reset()
 	buf.WriteString("utter nonsense\n;")

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -5,6 +5,7 @@ package dmorph_test
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"io/fs"
 	"log/slog"
@@ -33,7 +34,8 @@ func TestWithMigrationFromFile(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := dmorph.Run(db,
+	runErr := dmorph.Run(context.Background(),
+		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFile("testData/01_base_table.sql"))
 
@@ -57,7 +59,8 @@ func TestWithMigrationFromFileError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := dmorph.Run(db,
+	runErr := dmorph.Run(context.Background(),
+		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFile("testData/00_non_existent.sql"))
 
@@ -74,7 +77,7 @@ func TestMigrationFromFileFSError(t *testing.T) {
 
 	mig := dmorph.TmigrationFromFileFS("nonexistent", dir.FS(), slog.Default())
 
-	err := mig.Migrate(nil)
+	err := mig.Migrate(context.Background(), nil)
 
 	assert.Error(t, err, "expected error")
 }
@@ -104,7 +107,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 
 	assert.NoError(t, txErr, "expected no tx error")
 
-	err := dmorph.TapplyStepsStream(tx, &buf, "test", slog.Default())
+	err := dmorph.TapplyStepsStream(context.Background(), tx, &buf, "test", slog.Default())
 
 	assert.Error(t, err, "expected error")
 
@@ -117,7 +120,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 	buf.Reset()
 	buf.WriteString("utter nonsense\n;")
 
-	err = dmorph.TapplyStepsStream(tx, &buf, "test", slog.Default())
+	err = dmorph.TapplyStepsStream(context.Background(), tx, &buf, "test", slog.Default())
 
 	assert.Error(t, err, "expected error")
 

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -12,10 +12,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/AlphaOne1/dmorph"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWithMigrationFromFile(t *testing.T) {
@@ -72,11 +70,9 @@ func TestWithMigrationFromFileError(t *testing.T) {
 // TestMigrationFromFileFSError validates that migrationFromFileFS returns an error
 // when the specified file does not exist.
 func TestMigrationFromFileFSError(t *testing.T) {
-	dir, dirErr := os.OpenRoot("testData")
+	dir := os.DirFS("testData")
 
-	require.NoError(t, dirErr, "could not open test data directory")
-
-	mig := dmorph.TmigrationFromFileFS("nonexistent", dir.FS(), slog.Default())
+	mig := dmorph.TmigrationFromFileFS("nonexistent", dir, slog.Default())
 
 	err := mig.Migrate(context.Background(), nil)
 
@@ -104,7 +100,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 	buf := bytes.Buffer{}
 	buf.WriteString("utter nonsense")
 
-	tx, txErr := db.Begin()
+	tx, txErr := db.BeginTx(t.Context(), nil)
 
 	assert.NoError(t, txErr, "expected no tx error")
 
@@ -114,7 +110,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 
 	_ = tx.Rollback()
 
-	tx, txErr = db.Begin()
+	tx, txErr = db.BeginTx(t.Context(), nil)
 
 	assert.NoError(t, txErr, "expected no tx error")
 

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -5,7 +5,6 @@ package dmorph_test
 
 import (
 	"bytes"
-	"database/sql"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -17,21 +16,7 @@ import (
 )
 
 func TestWithMigrationFromFile(t *testing.T) {
-	dbFile, dbFileErr := prepareDB()
-
-	if dbFileErr != nil {
-		t.Errorf("DB file could not be created: %v", dbFileErr)
-	} else {
-		defer func() { _ = os.Remove(dbFile) }()
-	}
-
-	db, dbErr := sql.Open("sqlite", dbFile)
-
-	if dbErr != nil {
-		t.Errorf("DB file could not be created: %v", dbErr)
-	} else {
-		defer func() { _ = db.Close() }()
-	}
+	db, _ := openTempSQLite(t)
 
 	runErr := dmorph.Run(t.Context(),
 		db,
@@ -42,21 +27,7 @@ func TestWithMigrationFromFile(t *testing.T) {
 }
 
 func TestWithMigrationFromFileError(t *testing.T) {
-	dbFile, dbFileErr := prepareDB()
-
-	if dbFileErr != nil {
-		t.Errorf("DB file could not be created: %v", dbFileErr)
-	} else {
-		defer func() { _ = os.Remove(dbFile) }()
-	}
-
-	db, dbErr := sql.Open("sqlite", dbFile)
-
-	if dbErr != nil {
-		t.Errorf("DB file could not be created: %v", dbErr)
-	} else {
-		defer func() { _ = db.Close() }()
-	}
+	db, _ := openTempSQLite(t)
 
 	runErr := dmorph.Run(t.Context(),
 		db,
@@ -81,21 +52,7 @@ func TestMigrationFromFileFSError(t *testing.T) {
 
 // TestApplyStepsStreamError tests error handling in applyStepsStream.
 func TestApplyStepsStreamError(t *testing.T) {
-	dbFile, dbFileErr := prepareDB()
-
-	if dbFileErr != nil {
-		t.Errorf("DB file could not be created: %v", dbFileErr)
-	} else {
-		defer func() { _ = os.Remove(dbFile) }()
-	}
-
-	db, dbErr := sql.Open("sqlite", dbFile)
-
-	if dbErr != nil {
-		t.Errorf("DB file could not be created: %v", dbErr)
-	} else {
-		defer func() { _ = db.Close() }()
-	}
+	db, _ := openTempSQLite(t)
 
 	buf := bytes.Buffer{}
 	buf.WriteString("utter nonsense")

--- a/file_migration_test.go
+++ b/file_migration_test.go
@@ -5,7 +5,6 @@ package dmorph_test
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"io/fs"
 	"log/slog"
@@ -34,7 +33,7 @@ func TestWithMigrationFromFile(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := dmorph.Run(context.Background(),
+	runErr := dmorph.Run(t.Context(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFile("testData/01_base_table.sql"))
@@ -59,7 +58,7 @@ func TestWithMigrationFromFileError(t *testing.T) {
 		defer func() { _ = db.Close() }()
 	}
 
-	runErr := dmorph.Run(context.Background(),
+	runErr := dmorph.Run(t.Context(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFile("testData/00_non_existent.sql"))
@@ -75,7 +74,7 @@ func TestMigrationFromFileFSError(t *testing.T) {
 
 	mig := dmorph.TmigrationFromFileFS("nonexistent", dir, slog.Default())
 
-	err := mig.Migrate(context.Background(), nil)
+	err := mig.Migrate(t.Context(), nil)
 
 	assert.Error(t, err, "expected error")
 }
@@ -105,7 +104,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 
 	require.NoError(t, txErr, "expected no tx error")
 
-	err := dmorph.TapplyStepsStream(context.Background(), tx, &buf, "test", slog.Default())
+	err := dmorph.TapplyStepsStream(t.Context(), tx, &buf, "test", slog.Default())
 
 	require.Error(t, err, "expected error")
 
@@ -118,7 +117,7 @@ func TestApplyStepsStreamError(t *testing.T) {
 	buf.Reset()
 	buf.WriteString("utter nonsense\n;")
 
-	err = dmorph.TapplyStepsStream(context.Background(), tx, &buf, "test", slog.Default())
+	err = dmorph.TapplyStepsStream(t.Context(), tx, &buf, "test", slog.Default())
 
 	assert.Error(t, err, "expected error")
 

--- a/migration.go
+++ b/migration.go
@@ -224,6 +224,12 @@ func (m *Morpher) applyMigrations(ctx context.Context, db *sql.DB, lastMigration
 
 		m.Log.Info("applying migration", slog.String("file", migration.Key()))
 		startMigration = time.Now()
+
+		// Check context before starting a transaction
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context cancelled before migration %s: %w", migration.Key(), err)
+		}
+
 		tx, txBeginErr := db.Begin()
 
 		if txBeginErr != nil {

--- a/migration.go
+++ b/migration.go
@@ -280,7 +280,7 @@ func (m *Morpher) checkAppliedMigrations(appliedMigrations []string) error {
 	}
 
 	// we know here that there are at least as many migrations applied as we got to apply
-	for i := 0; i < len(appliedMigrations); i++ {
+	for i := range appliedMigrations {
 		if appliedMigrations[i] != m.Migrations[i].Key() {
 			return ErrMigrationsUnrelated
 		}

--- a/migration_test.go
+++ b/migration_test.go
@@ -58,11 +58,12 @@ func TestMigration(t *testing.T) {
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
-	assert.NoError(t, migrationsDirErr, "migrations directory could not be opened")
+	require.NoError(t, migrationsDirErr, "migrations directory could not be opened")
 
 	runErr := dmorph.Run(db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
-		dmorph.WithMigrationsFromFS(migrationsDir.(fs.ReadDirFS)))
+		dmorph.WithMigrationsFromFS(
+			migrationsDir.(fs.ReadDirFS))) // Safe: migrationDir guaranteed to implement fs.ReadDirFS
 
 	assert.NoError(t, runErr, "migrations could not be run")
 }
@@ -97,7 +98,8 @@ func TestMigrationUpdate(t *testing.T) {
 
 	runErr = dmorph.Run(db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
-		dmorph.WithMigrationsFromFS(migrationsDir.(fs.ReadDirFS)))
+		dmorph.WithMigrationsFromFS(
+			migrationsDir.(fs.ReadDirFS))) // Safe: migrationDir guaranteed to implement fs.ReadDirFS
 
 	assert.NoError(t, runErr, "migrations could not be run")
 }

--- a/migration_test.go
+++ b/migration_test.go
@@ -39,7 +39,7 @@ func prepareDB() (string, error) {
 	return result, nil
 }
 
-func openTempSQLite(t *testing.T) (*sql.DB, string) {
+func openTempSQLite(t *testing.T) *sql.DB {
 	t.Helper()
 
 	dbFile, err := prepareDB()
@@ -50,12 +50,12 @@ func openTempSQLite(t *testing.T) (*sql.DB, string) {
 	require.NoError(t, dbErr, "DB could not be opened")
 	t.Cleanup(func() { _ = db.Close() })
 
-	return db, dbFile
+	return db
 }
 
 // TestMigration tests the happy flow.
 func TestMigration(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -71,7 +71,7 @@ func TestMigration(t *testing.T) {
 
 // TestMigrationUpdate tests the happy flow of updating on existing migrations.
 func TestMigrationUpdate(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -103,7 +103,7 @@ func (m TestMigrationImpl) Migrate(ctx context.Context, tx *sql.Tx) error {
 
 // TestWithMigrations tests the adding of migrations using WithMigrations.
 func TestWithMigrations(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	runErr := dmorph.Run(t.Context(),
 		db,
@@ -123,7 +123,7 @@ func TestMigrationUnableToCreateMorpher(t *testing.T) {
 
 // TestMigrationTooOld tests what happens if the applied migrations are too old.
 func TestMigrationTooOld(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -146,7 +146,7 @@ func TestMigrationTooOld(t *testing.T) {
 
 // TestMigrationUnrelated0 tests what happens if the applied migrations are unrelated to existing ones.
 func TestMigrationUnrelated0(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -169,7 +169,7 @@ func TestMigrationUnrelated0(t *testing.T) {
 
 // TestMigrationUnrelated1 tests what happens if the applied migrations are unrelated to existing ones.
 func TestMigrationUnrelated1(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -193,7 +193,7 @@ func TestMigrationUnrelated1(t *testing.T) {
 // TestMigrationAppliedUnordered tests the case, that somehow the migrations in the
 // database are registered not in the order of their keys.
 func TestMigrationAppliedUnordered(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
@@ -380,7 +380,7 @@ func TestMigrationRunInvalid(t *testing.T) {
 // TestMigrationRunInvalidCreate tests the behavior of running a migration
 // with an invalid CreateTemplate in the dialect.
 func TestMigrationRunInvalidCreate(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	dialect := dmorph.DialectSQLite()
 	dialect.CreateTemplate = "utter nonsense"
@@ -398,7 +398,7 @@ func TestMigrationRunInvalidCreate(t *testing.T) {
 
 // TestMigrationRunInvalidApplied tests the failure scenario where the AppliedTemplate of the dialect is invalid.
 func TestMigrationRunInvalidApplied(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	dialect := dmorph.DialectSQLite()
 	dialect.AppliedTemplate = "utter nonsense"
@@ -416,7 +416,7 @@ func TestMigrationRunInvalidApplied(t *testing.T) {
 
 // TestMigrationApplyInvalidDB verifies that applying migrations to an invalid or closed database results in an error.
 func TestMigrationApplyInvalidDB(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	morpher, morpherErr := dmorph.NewMorpher(
 		dmorph.WithDialect(dmorph.DialectSQLite()),
@@ -431,7 +431,7 @@ func TestMigrationApplyInvalidDB(t *testing.T) {
 
 // TestMigrationApplyUnableRegister tests the behavior when the migration registration fails due to an invalid template.
 func TestMigrationApplyUnableRegister(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	morpher, morpherErr := dmorph.NewMorpher(
 		dmorph.WithDialect(dmorph.DialectSQLite()),
@@ -453,7 +453,7 @@ func TestMigrationApplyUnableRegister(t *testing.T) {
 // TestMigrationApplyUnableCommit tests the scenario where a migration application fails
 // due to inability to commit a transaction.
 func TestMigrationApplyUnableCommit(t *testing.T) {
-	db, _ := openTempSQLite(t)
+	db := openTempSQLite(t)
 
 	morpher, morpherErr := dmorph.NewMorpher(
 		dmorph.WithDialect(dmorph.DialectSQLite()),

--- a/migration_test.go
+++ b/migration_test.go
@@ -89,7 +89,7 @@ func TestMigrationUpdate(t *testing.T) {
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
-	assert.NoError(t, migrationsDirErr, "migrations directory could not be opened")
+	require.NoError(t, migrationsDirErr, "migrations directory could not be opened")
 
 	runErr := dmorph.Run(context.Background(),
 		db,
@@ -206,14 +206,14 @@ func TestMigrationUnrelated0(t *testing.T) {
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
-	assert.NoError(t, migrationsDirErr, "migrations directory could not be opened")
+	require.NoError(t, migrationsDirErr, "migrations directory could not be opened")
 
 	runErr := dmorph.Run(context.Background(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationsFromFS(migrationsDir))
 
-	assert.NoError(t, runErr, "preparation migrations could not be run")
+	require.NoError(t, runErr, "preparation migrations could not be run")
 
 	runErr = dmorph.Run(context.Background(),
 		db,
@@ -243,7 +243,7 @@ func TestMigrationUnrelated1(t *testing.T) {
 
 	migrationsDir, migrationsDirErr := fs.Sub(testMigrationsDir, "testData")
 
-	assert.NoError(t, migrationsDirErr, "migrations directory could not be opened")
+	require.NoError(t, migrationsDirErr, "migrations directory could not be opened")
 
 	runErr := dmorph.Run(context.Background(),
 		db,

--- a/migration_test.go
+++ b/migration_test.go
@@ -97,7 +97,7 @@ func TestMigrationUpdate(t *testing.T) {
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFileFS("01_base_table.sql", migrationsDir))
 
-	assert.NoError(t, runErr, "preparation migrations could not be run")
+	require.NoError(t, runErr, "preparation migrations could not be run")
 
 	runErr = dmorph.Run(context.Background(),
 		db,
@@ -176,7 +176,8 @@ func TestMigrationTooOld(t *testing.T) {
 	runErr := dmorph.Run(context.Background(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
-		dmorph.WithMigrationsFromFS(migrationsDir.(fs.ReadDirFS)))
+		dmorph.WithMigrationsFromFS(
+			migrationsDir.(fs.ReadDirFS))) // Safe: migrationDir guaranteed to implement fs.ReadDirFS
 
 	require.NoError(t, runErr, "preparation migrations could not be run")
 
@@ -213,7 +214,8 @@ func TestMigrationUnrelated0(t *testing.T) {
 	runErr := dmorph.Run(context.Background(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
-		dmorph.WithMigrationsFromFS(migrationsDir.(fs.ReadDirFS)))
+		dmorph.WithMigrationsFromFS(
+			migrationsDir.(fs.ReadDirFS))) // Safe: migrationDir guaranteed to implement fs.ReadDirFS
 
 	assert.NoError(t, runErr, "preparation migrations could not be run")
 
@@ -252,7 +254,7 @@ func TestMigrationUnrelated1(t *testing.T) {
 		dmorph.WithDialect(dmorph.DialectSQLite()),
 		dmorph.WithMigrationFromFileFS("01_base_table.sql", migrationsDir))
 
-	assert.NoError(t, runErr, "preparation migrations could not be run")
+	require.NoError(t, runErr, "preparation migrations could not be run")
 
 	runErr = dmorph.Run(context.Background(),
 		db,
@@ -297,7 +299,8 @@ func TestMigrationAppliedUnordered(t *testing.T) {
 	runErr := dmorph.Run(context.Background(),
 		db,
 		dmorph.WithDialect(dmorph.DialectSQLite()),
-		dmorph.WithMigrationsFromFS(migrationsDir.(fs.ReadDirFS)))
+		dmorph.WithMigrationsFromFS(
+			migrationsDir.(fs.ReadDirFS))) // Safe: migrationDir guaranteed to implement fs.ReadDirFS
 
 	assert.ErrorIs(t,
 		runErr,
@@ -489,7 +492,7 @@ func TestMigrationRunInvalidCreate(t *testing.T) {
 		dmorph.WithDialect(dialect),
 		dmorph.WithMigrationFromFile("testData/01_base_table.sql"))
 
-	assert.NoError(t, morpherErr, "morpher could not be created")
+	require.NoError(t, morpherErr, "morpher could not be created")
 
 	runErr := morpher.Run(context.Background(), db)
 
@@ -521,7 +524,7 @@ func TestMigrationRunInvalidApplied(t *testing.T) {
 		dmorph.WithDialect(dialect),
 		dmorph.WithMigrationFromFile("testData/01_base_table.sql"))
 
-	assert.NoError(t, morpherErr, "morpher could not be created")
+	require.NoError(t, morpherErr, "morpher could not be created")
 
 	runErr := morpher.Run(context.Background(), db)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Minor wording and comment clarifications.

* **Tests**
  * Many tests converted to external-package style and updated to exercise the public API.
  * Added test-accessible helpers and exported wrappers to support testing.

* **Public API**
  * Core APIs and migration flows now accept context for cancellation/timeouts; signatures updated.

* **Refactor**
  * Context propagation added throughout migration and execution flows.

* **Chores**
  * Linter/configuration expanded and CI workflow comment/header typo and license header updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->